### PR TITLE
Release 0.0.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.9" %}
+{% set version = "0.0.10" %}
 
 package:
   name: splauncher
@@ -7,10 +7,10 @@ package:
 source:
   fn: splauncher-{{ version }}.tar.gz
   url: https://pypi.org/packages/source/s/splauncher/splauncher-{{ version }}.tar.gz
-  sha256: 03ad8f51cf5199022400369cccc4c8742d103c1b6a91b5a2ab4d05ce1110f40c
+  sha256: 8019ab1dda0470d4f74422ce713fe3cc44d76618f5706aaa1bd9b553d72b3dea
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -28,6 +28,7 @@ test:
 about:
   home: https://github.com/jakirkham/splauncher
   license: BSD 3-Clause
+  license_file: LICENSE.txt
   summary: A simple subprocess launcher with optional DRMAA support.
   doc_url: https://splauncher.readthedocs.io/
   dev_url: https://github.com/jakirkham/splauncher


### PR DESCRIPTION
```markdown
### v0.0.10

* Fix CIs. #33
* Point Anaconda badge to conda-forge. #32
* Include the license file. #31
* Pin conda-build to 1.x. #35
* Drop Sphinx 1.3 pin. #38
* Add the Read the Docs badge. #37
* Unpin conda-build from 1.x. #39
* Drop doc and conda package deployment. #34
* Fix docstring coverage measurement. #40
* Support coverage 4.x. #42
* Add `pragma: no cover` to `exclude_lines`. #43
* Tidy up. #45
* Only use the Read the Docs badge. #46
* Use shields.io's license badge. #47
* Tidy badges. #48
* Add PyPI badge. #49
* Skip handling test requirements for `bdist_conda`. #50
* Use unittests. #51
* Specify type of BSD in setup metadata. #52
* Drop nose from docs. #53
* Fix versioneer 0.15 install. #54
* Upgrade to versioneer 0.18. #55
* Freshen setup metadata. #56
* Support Python 3.4. #57
* Support Python 3.6. #58
* Drop native specification. #60
* Specify hostname for stdout and stderr files. #61
```

Note: Also package the license file now that it is available.